### PR TITLE
remove auth plugin command option (removed in MySQL 9)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
 
   mysql:
     image: "mysql"
-    command: --default-authentication-plugin=mysql_native_password
     #ports:
       #- "3306:3306"
     volumes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,6 @@ services:
 
   mysql:
     image: "mysql"
-    command: --default-authentication-plugin=mysql_native_password
     ports:
       - "3306:3306"
     volumes:


### PR DESCRIPTION
I encountered the same issue reported in #39 

The MySQL container has been upgraded to 9.0

The mysql_native_password authentication plugin was deprecated in 8.0 and removed in 9.0 ([release note](https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html#:~:text=The%20mysql_native_password%20authentication%20plugin%2C%20deprecated,into%20a%20dynamically%20loadable%20plugin.)).

The new default seems to be acceptable, so I just removed this configuration.